### PR TITLE
Fix mobile chat zoom and viewport issues

### DIFF
--- a/components/ChatGPT.tsx
+++ b/components/ChatGPT.tsx
@@ -485,12 +485,14 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
           background: transparent;
           resize: none;
           outline: none;
-          font-size: 15px;
+          font-size: 16px;
           line-height: 1.5;
           max-height: 120px;
           min-height: 24px;
           color: #0d1117;
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+          transform: translateZ(0);
+          -webkit-appearance: none;
         }
 
         .chatgpt-input::placeholder {

--- a/components/ChatGPT.tsx
+++ b/components/ChatGPT.tsx
@@ -497,6 +497,12 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
           transform: translateZ(0);
           -webkit-appearance: none;
+          -webkit-user-select: text !important;
+          -moz-user-select: text !important;
+          -ms-user-select: text !important;
+          user-select: text !important;
+          -webkit-tap-highlight-color: transparent;
+          -webkit-touch-callout: default;
         }
 
         .chatgpt-input::placeholder {
@@ -581,7 +587,7 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
             max-width: 85%;
           }
 
-          /* Предотвращаем зум ��ри фокусе на input */
+          /* Предотвращаем зум при фокусе на input */
           input, textarea, select {
             font-size: 16px !important;
             transform: translateZ(0);

--- a/components/ChatGPT.tsx
+++ b/components/ChatGPT.tsx
@@ -533,12 +533,15 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
         @media (max-width: 768px) {
           .chatgpt-overlay {
             padding: 0;
+            touch-action: manipulation;
           }
 
           .chatgpt-container {
             height: 100vh;
             max-width: 100%;
             border-radius: 0;
+            position: fixed;
+            overflow: hidden;
           }
 
           .chatgpt-header {
@@ -547,14 +550,37 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
 
           .chatgpt-messages {
             padding: 20px 16px;
+            height: calc(100vh - 140px);
+            overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
           }
 
           .chatgpt-input-area {
             padding: 16px 20px;
+            position: relative;
+            background: #f7f7f8;
+          }
+
+          .input-container {
+            position: relative;
+          }
+
+          .chatgpt-input {
+            font-size: 16px !important;
+            transform: translateZ(0);
+            -webkit-appearance: none;
+            -webkit-user-select: text;
+            touch-action: manipulation;
           }
 
           .message {
             max-width: 85%;
+          }
+
+          /* Предотвращаем зум при фокусе на input */
+          input, textarea, select {
+            font-size: 16px !important;
+            transform: translateZ(0);
           }
         }
       `}</style>

--- a/components/ChatGPT.tsx
+++ b/components/ChatGPT.tsx
@@ -403,6 +403,10 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
           line-height: 1.6;
           word-wrap: break-word;
           position: relative;
+          -webkit-user-select: text !important;
+          -moz-user-select: text !important;
+          -ms-user-select: text !important;
+          user-select: text !important;
         }
 
         .user-message .message-bubble {
@@ -577,7 +581,7 @@ export default function ChatGPT({ isOpen, onClose }: ChatGPTProps) {
             max-width: 85%;
           }
 
-          /* Предотвращаем зум при фокусе на input */
+          /* Предотвращаем зум ��ри фокусе на input */
           input, textarea, select {
             font-size: 16px !important;
             transform: translateZ(0);

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,9 +4,12 @@ export default function Document() {
   return (
     <Html lang="ru">
       <Head>
+        {/* Viewport meta tag для предотвращения зума на мобильных */}
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
         {/* Скрипт защиты от просмотра кода */}
         <script src="/protection.js" />
-        
+
         {/* Встроенная защита */}
         <script
           dangerouslySetInnerHTML={{

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,6 +28,35 @@
   context-menu: none !important;
 }
 
+/* Предотвращение зума на мобильных устройствах */
+@media screen and (max-width: 768px) {
+  html {
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  body {
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    touch-action: manipulation;
+  }
+
+  input, textarea, select {
+    font-size: 16px !important;
+    transform: translateZ(0);
+    -webkit-appearance: none;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+  }
+
+  /* Предотвращаем зум при двойном тапе */
+  * {
+    touch-action: manipulation;
+  }
+}
+
 *::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
## Purpose
The user reported issues with the mobile chat interface where the chat would zoom in when typing, creating a poor user experience. They needed fixes for mobile viewport behavior and input field zoom prevention.

## Code changes
- **Viewport configuration**: Added viewport meta tag with `user-scalable=no` to prevent zoom
- **Input field fixes**: Set font-size to 16px on all inputs to prevent iOS auto-zoom
- **Mobile CSS improvements**: 
  - Added `touch-action: manipulation` to prevent double-tap zoom
  - Fixed chat container positioning with `position: fixed`
  - Improved mobile layout with proper height calculations
  - Added `-webkit-text-size-adjust: 100%` for consistent text sizing
- **Text selection**: Enhanced user-select properties for better text interaction
- **Scrolling**: Added `-webkit-overflow-scrolling: touch` for smooth mobile scrolling

These changes ensure the mobile chat interface remains at a consistent zoom level and provides a better user experience on mobile devices.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d77ccc901f194f2f9b5c7bd88ea973e3/curry-sanctuary)

👀 [Preview Link](https://d77ccc901f194f2f9b5c7bd88ea973e3-curry-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d77ccc901f194f2f9b5c7bd88ea973e3</projectId>-->
<!--<branchName>curry-sanctuary</branchName>-->