### PR TITLE
Replace JARVIS SVG icons with custom avatar image

### DIFF
--- a/components/JarvisChat.tsx
+++ b/components/JarvisChat.tsx
@@ -152,12 +152,13 @@ export default function JarvisChat({ isOpen, onClose }: JarvisChatProps) {
         <div className="jarvis-chat-header">
           <div className="jarvis-chat-title">
             <div className="jarvis-avatar">
-              <div className="jarvis-icon">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                  <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M9 12l2 2 4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
-              </div>
+              <img
+                src="https://cdn.builder.io/api/v1/image/assets%2F86ccad5be3604b288119b4c361741253%2F60b029911e0b4e74939cea888d93edb9?format=webp&width=800"
+                alt="JARVIS"
+                width="32"
+                height="32"
+                style={{borderRadius: '50%', objectFit: 'cover'}}
+              />
             </div>
             <div className="title-info">
               <h3>ДЖАРВИС</h3>
@@ -183,12 +184,13 @@ export default function JarvisChat({ isOpen, onClose }: JarvisChatProps) {
             >
               {!message.isUser && (
                 <div className="message-avatar">
-                  <div className="ai-icon">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                      <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                      <path d="M9 12l2 2 4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                    </svg>
-                  </div>
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F86ccad5be3604b288119b4c361741253%2F60b029911e0b4e74939cea888d93edb9?format=webp&width=800"
+                    alt="JARVIS"
+                    width="28"
+                    height="28"
+                    style={{borderRadius: '50%', objectFit: 'cover'}}
+                  />
                 </div>
               )}
               <div className="message-content">
@@ -207,12 +209,13 @@ export default function JarvisChat({ isOpen, onClose }: JarvisChatProps) {
           {isTyping && (
             <div className="message ai-message">
               <div className="message-avatar">
-                <div className="ai-icon">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                    <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                    <path d="M9 12l2 2 4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                  </svg>
-                </div>
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F86ccad5be3604b288119b4c361741253%2F60b029911e0b4e74939cea888d93edb9?format=webp&width=800"
+                  alt="JARVIS"
+                  width="28"
+                  height="28"
+                  style={{borderRadius: '50%', objectFit: 'cover'}}
+                />
               </div>
               <div className="message-content">
                 <div className="message-bubble typing-indicator">

--- a/components/JarvisChat.tsx
+++ b/components/JarvisChat.tsx
@@ -384,17 +384,8 @@ export default function JarvisChat({ isOpen, onClose }: JarvisChatProps) {
           height: 28px;
           flex-shrink: 0;
           margin-top: 2px;
-        }
-
-        .ai-icon {
-          width: 28px;
-          height: 28px;
-          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
           border-radius: 50%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          color: white;
+          overflow: hidden;
         }
 
         .message-content {

--- a/components/JarvisChat.tsx
+++ b/components/JarvisChat.tsx
@@ -303,12 +303,11 @@ export default function JarvisChat({ isOpen, onClose }: JarvisChatProps) {
         .jarvis-avatar {
           width: 32px;
           height: 32px;
-          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
           border-radius: 50%;
           display: flex;
           align-items: center;
           justify-content: center;
-          color: white;
+          overflow: hidden;
         }
 
         .jarvis-icon {

--- a/components/JarvisChatEnhanced.tsx
+++ b/components/JarvisChatEnhanced.tsx
@@ -124,7 +124,7 @@ export default function JarvisChatEnhanced({ isOpen, onClose }: JarvisChatProps)
       
       const fallbackResponses = [
         'Извините, у меня временные проблемы с подключением к AI-серверу. Попробуйте еще раз через несколько секунд.',
-        'Сейчас испытываю технические трудности, но я ДЖАРВИС и готов помочь! Попробуйте переформулировать вопрос.',
+        'Сейчас исп��тываю технические трудности, но я ДЖАРВИС и готов помочь! Попробуйте переформулировать вопрос.',
         'Произошла ошибка связи, но не волнуйтесь - я здесь. Напишите мне в Telegram  для прямой связи.',
       ]
       
@@ -264,7 +264,7 @@ export default function JarvisChatEnhanced({ isOpen, onClose }: JarvisChatProps)
             <div className="jarvis-chat-title">
               <div className="jarvis-avatar">
                 <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2Ff21efa9d331c44c6b55bad01cab8169b%2F342e3ad8cb1542ae9b5155023da06c0d?format=webp&width=800"
+                  src="https://cdn.builder.io/api/v1/image/assets%2F86ccad5be3604b288119b4c361741253%2F60b029911e0b4e74939cea888d93edb9?format=webp&width=800"
                   alt="JARVIS"
                   width="20"
                   height="20"
@@ -295,7 +295,7 @@ export default function JarvisChatEnhanced({ isOpen, onClose }: JarvisChatProps)
                 {!message.isUser && (
                   <div className="message-avatar">
                     <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2Ff21efa9d331c44c6b55bad01cab8169b%2F342e3ad8cb1542ae9b5155023da06c0d?format=webp&width=800"
+                      src="https://cdn.builder.io/api/v1/image/assets%2F86ccad5be3604b288119b4c361741253%2F60b029911e0b4e74939cea888d93edb9?format=webp&width=800"
                       alt="JARVIS"
                       width="20"
                       height="20"
@@ -319,7 +319,7 @@ export default function JarvisChatEnhanced({ isOpen, onClose }: JarvisChatProps)
               <div className="message ai-message">
                 <div className="message-avatar">
                   <img
-                    src="https://cdn.builder.io/api/v1/image/assets%2Ff21efa9d331c44c6b55bad01cab8169b%2F342e3ad8cb1542ae9b5155023da06c0d?format=webp&width=800"
+                    src="https://cdn.builder.io/api/v1/image/assets%2F86ccad5be3604b288119b4c361741253%2F60b029911e0b4e74939cea888d93edb9?format=webp&width=800"
                     alt="JARVIS"
                     width="16"
                     height="16"


### PR DESCRIPTION
## Purpose

The user requested to replace the default SVG icons in the JARVIS chat interface with a custom avatar image they provided. This change aims to personalize the chat experience and give JARVIS a more distinctive visual identity.

## Code changes

- **JarvisChat.tsx**: Replaced all SVG shield icons with `<img>` elements using the new avatar URL
  - Updated chat header avatar (32x32px)
  - Updated message avatars for AI responses (28x28px) 
  - Updated typing indicator avatar (28x28px)
  - Removed gradient background styling and updated CSS for image containers
  - Added proper image styling with border-radius and object-fit

- **JarvisChatEnhanced.tsx**: Updated avatar image URLs to use the new custom image
  - Replaced previous Builder.io image URL with the new one across all avatar instances
  - Maintained consistent sizing (20x20px for header, 16px for messages)

The new avatar image is hosted on Builder.io CDN and displays as a circular profile picture throughout the chat interface.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 28`

🔗 [Edit in Builder.io](https://builder.io/app/projects/223284a2a25f41bd8c600573df709673/spark-den)

👀 [Preview Link](https://223284a2a25f41bd8c600573df709673-spark-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>223284a2a25f41bd8c600573df709673</projectId>-->
<!--<branchName>spark-den</branchName>-->